### PR TITLE
Changes due to domain name validation behaviour

### DIFF
--- a/Nager.PublicSuffix.TestConsole/Program.cs
+++ b/Nager.PublicSuffix.TestConsole/Program.cs
@@ -17,9 +17,14 @@ namespace Nager.PublicSuffix.TestConsole
             LoadFromFile();
 
             Console.WriteLine();
-            Console.WriteLine("Performance");
+            Console.WriteLine("Performance (UriNormalization)");
             Console.WriteLine("------------------------------");
-            Performance();
+            Performance(true);
+
+            Console.WriteLine();
+            Console.WriteLine("Performance (IdnMappingNormalization)");
+            Console.WriteLine("------------------------------");
+            Performance(false);
 
             Console.WriteLine();
             Console.WriteLine("----------- DONE -------------");
@@ -55,9 +60,20 @@ namespace Nager.PublicSuffix.TestConsole
             Console.WriteLine("SubDomain:{0}", domainInfo.SubDomain);
         }
 
-        public static void Performance()
+        public static void Performance(bool useUriNormalization)
         {
-            var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"));
+            IDomainNormalizer normalizer;
+
+            if (useUriNormalization)
+            {
+                normalizer = new UriNormalizer();
+            }
+            else
+            {
+                normalizer = new IdnMappingNormalizer();
+            }
+
+            var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"), normalizer);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Nager.PublicSuffix.UnitTest/DomainNameTest.cs
+++ b/Nager.PublicSuffix.UnitTest/DomainNameTest.cs
@@ -19,6 +19,7 @@ namespace Nager.PublicSuffix.UnitTest
             Assert.AreEqual("com", domainName.TLD);
             Assert.AreEqual("test.com", domainName.RegistrableDomain);
             Assert.AreEqual(null, domainName.SubDomain);
+            Assert.AreEqual("com", domainName.TLDRule.Name);
         }
 
         [TestMethod]
@@ -35,6 +36,7 @@ namespace Nager.PublicSuffix.UnitTest
             Assert.AreEqual("co.uk", domainName.TLD);
             Assert.AreEqual("test.co.uk", domainName.RegistrableDomain);
             Assert.AreEqual(null, domainName.SubDomain);
+            Assert.AreEqual("co.uk", domainName.TLDRule.Name);
         }
 
         [TestMethod]
@@ -51,6 +53,7 @@ namespace Nager.PublicSuffix.UnitTest
             Assert.AreEqual("co.uk", domainName.TLD);
             Assert.AreEqual("test.co.uk", domainName.RegistrableDomain);
             Assert.AreEqual("sub", domainName.SubDomain);
+            Assert.AreEqual("co.uk", domainName.TLDRule.Name);
         }
     }
 }

--- a/Nager.PublicSuffix.UnitTest/DomainNameTest.cs
+++ b/Nager.PublicSuffix.UnitTest/DomainNameTest.cs
@@ -55,5 +55,39 @@ namespace Nager.PublicSuffix.UnitTest
             Assert.AreEqual("sub", domainName.SubDomain);
             Assert.AreEqual("co.uk", domainName.TLDRule.Name);
         }
+
+        [TestMethod]
+        public void CheckDomainName4()
+        {
+            var rules = new List<TldRule>();
+            rules.Add(new TldRule("uk"));
+            rules.Add(new TldRule("co.uk"));
+            rules.Add(new TldRule("*.sch.uk"));
+
+            var domainParser = new DomainParser(rules);
+
+            var domainName = domainParser.Get("sub.test1.test2.sch.uk");
+            Assert.AreEqual("test1", domainName.Domain);
+            Assert.AreEqual("test2.sch.uk", domainName.TLD);
+            Assert.AreEqual("test1.test2.sch.uk", domainName.RegistrableDomain);
+            Assert.AreEqual("sub", domainName.SubDomain);
+            Assert.AreEqual("*.sch.uk", domainName.TLDRule.Name);
+        }
+
+        [TestMethod]
+        public void CheckDomainNameForUnlistedTld()
+        {
+            var rules = new List<TldRule>();
+            rules.Add(new TldRule("uk"));
+            rules.Add(new TldRule("co.uk"));
+            var domainParser = new DomainParser(rules);
+
+            var domainName = domainParser.Get("unlisted.domain.example");
+            Assert.AreEqual("domain", domainName.Domain);
+            Assert.AreEqual("example", domainName.TLD);
+            Assert.AreEqual("domain.example", domainName.RegistrableDomain);
+            Assert.AreEqual("unlisted", domainName.SubDomain);
+            Assert.AreEqual("*", domainName.TLDRule.Name);
+        }
     }
 }

--- a/Nager.PublicSuffix.UnitTest/DomainNameTest.cs
+++ b/Nager.PublicSuffix.UnitTest/DomainNameTest.cs
@@ -3,18 +3,17 @@ using System.Collections.Generic;
 
 namespace Nager.PublicSuffix.UnitTest
 {
-    [TestClass]
-    public class DomainNameTest
+    public abstract class DomainNameTest
     {
         [TestMethod]
         public void CheckDomainName1()
         {
             var rules = new List<TldRule>();
             rules.Add(new TldRule("com"));
-
-            var domainParser = new DomainParser(rules);
+            var domainParser = this.GetParserForRules(rules);
 
             var domainName = domainParser.Get("test.com");
+
             Assert.AreEqual("test", domainName.Domain);
             Assert.AreEqual("com", domainName.TLD);
             Assert.AreEqual("test.com", domainName.RegistrableDomain);
@@ -28,10 +27,10 @@ namespace Nager.PublicSuffix.UnitTest
             var rules = new List<TldRule>();
             rules.Add(new TldRule("uk"));
             rules.Add(new TldRule("co.uk"));
-
-            var domainParser = new DomainParser(rules);
+            var domainParser = this.GetParserForRules(rules);
 
             var domainName = domainParser.Get("test.co.uk");
+
             Assert.AreEqual("test", domainName.Domain);
             Assert.AreEqual("co.uk", domainName.TLD);
             Assert.AreEqual("test.co.uk", domainName.RegistrableDomain);
@@ -45,10 +44,10 @@ namespace Nager.PublicSuffix.UnitTest
             var rules = new List<TldRule>();
             rules.Add(new TldRule("uk"));
             rules.Add(new TldRule("co.uk"));
-
-            var domainParser = new DomainParser(rules);
+            var domainParser = this.GetParserForRules(rules);
 
             var domainName = domainParser.Get("sub.test.co.uk");
+
             Assert.AreEqual("test", domainName.Domain);
             Assert.AreEqual("co.uk", domainName.TLD);
             Assert.AreEqual("test.co.uk", domainName.RegistrableDomain);
@@ -63,10 +62,10 @@ namespace Nager.PublicSuffix.UnitTest
             rules.Add(new TldRule("uk"));
             rules.Add(new TldRule("co.uk"));
             rules.Add(new TldRule("*.sch.uk"));
-
-            var domainParser = new DomainParser(rules);
+            var domainParser = this.GetParserForRules(rules);
 
             var domainName = domainParser.Get("sub.test1.test2.sch.uk");
+
             Assert.AreEqual("test1", domainName.Domain);
             Assert.AreEqual("test2.sch.uk", domainName.TLD);
             Assert.AreEqual("test1.test2.sch.uk", domainName.RegistrableDomain);
@@ -80,14 +79,17 @@ namespace Nager.PublicSuffix.UnitTest
             var rules = new List<TldRule>();
             rules.Add(new TldRule("uk"));
             rules.Add(new TldRule("co.uk"));
-            var domainParser = new DomainParser(rules);
+            var domainParser = this.GetParserForRules(rules);
 
             var domainName = domainParser.Get("unlisted.domain.example");
+
             Assert.AreEqual("domain", domainName.Domain);
             Assert.AreEqual("example", domainName.TLD);
             Assert.AreEqual("domain.example", domainName.RegistrableDomain);
             Assert.AreEqual("unlisted", domainName.SubDomain);
             Assert.AreEqual("*", domainName.TLDRule.Name);
         }
+
+        protected abstract DomainParser GetParserForRules(List<TldRule> rules);
     }
 }

--- a/Nager.PublicSuffix.UnitTest/DomainNameTestsWithIdnMappingNormalization.cs
+++ b/Nager.PublicSuffix.UnitTest/DomainNameTestsWithIdnMappingNormalization.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Nager.PublicSuffix.UnitTest
+{
+    [TestClass]
+    public class DomainNameTestsWithIdnMappingNormalization : DomainNameTest
+    {
+        protected override DomainParser GetParserForRules(List<TldRule> rules)
+        {
+            return new DomainParser(rules, new IdnMappingNormalizer());
+        }
+    }
+}

--- a/Nager.PublicSuffix.UnitTest/DomainNameTestsWithUriNormalization.cs
+++ b/Nager.PublicSuffix.UnitTest/DomainNameTestsWithUriNormalization.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Nager.PublicSuffix.UnitTest
+{
+    [TestClass]
+    public class DomainNameTestsWithUriNormalization : DomainNameTest
+    {
+        protected override DomainParser GetParserForRules(List<TldRule> rules)
+        {
+            return new DomainParser(rules, new UriNormalizer());
+        }
+    }
+}

--- a/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
+++ b/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
@@ -55,6 +55,8 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AsyncAwaitTest.cs" />
+    <Compile Include="DomainNameTestsWithIdnMappingNormalization.cs" />
+    <Compile Include="DomainNameTestsWithUriNormalization.cs" />
     <Compile Include="PublicSuffixTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="PublicSuffixTestsWithIdnMappingNormalization.cs" />

--- a/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
+++ b/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
@@ -57,6 +57,8 @@
     <Compile Include="AsyncAwaitTest.cs" />
     <Compile Include="PublicSuffixTest.cs" />
     <Compile Include="DomainNameTest.cs" />
+    <Compile Include="PublicSuffixTestsWithIdnMappingNormalization.cs" />
+    <Compile Include="PublicSuffixTestsWithUriNormalization.cs" />
     <Compile Include="TldRuleTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ParseTest.cs" />

--- a/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
+++ b/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
@@ -57,6 +57,7 @@
     <Compile Include="AsyncAwaitTest.cs" />
     <Compile Include="DomainNameTestsWithIdnMappingNormalization.cs" />
     <Compile Include="DomainNameTestsWithUriNormalization.cs" />
+    <Compile Include="NormalizationVariationTests.cs" />
     <Compile Include="PublicSuffixTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="PublicSuffixTestsWithIdnMappingNormalization.cs" />

--- a/Nager.PublicSuffix.UnitTest/NormalizationVariationTests.cs
+++ b/Nager.PublicSuffix.UnitTest/NormalizationVariationTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Nager.PublicSuffix.UnitTest
+{
+    // Matching TLDs against entries in the PublicSuffix list requires punycode be translated into UTF8
+    // This can be accomplised either by using the Uri class or the IdnMapping class.
+    // Both methods are constrasted here.
+    // These tests demonstrate how the Uri class is performing additional validation/transformation on the domain name
+    // Consumers of the DomainParser who are realy interested in the use of the PublicSuffix list to
+    // examine behaviour around TLDs and their presence/absence/rules may not wish the outcomes to be
+    // influenced by other rules imposed by the Uri class
+    [TestClass]
+    public class NormalizationVariationTests
+    {
+        private DomainParser _parserUsingUriNormalization;
+        private DomainParser _parserUsingIdnNormalization;
+
+        [TestInitialize()]
+        public void Initialize()
+        {
+            var rules = new List<TldRule>();
+            rules.Add(new TldRule("com"));
+            this._parserUsingUriNormalization = new DomainParser(rules, new UriNormalizer());
+            this._parserUsingIdnNormalization = new DomainParser(rules, new IdnMappingNormalizer());
+        }
+
+        [TestMethod]
+        public void UnderscoreBasedVariations()
+        {
+            // this test reveals the motivation for creating a different method of normalization because of the handling of underscore characters
+            // by the Uri class.
+            // Some online services require the creation of DNS CNAME records for "DomainKeys Identified Mail" (DKIM) which
+            // may have values formatted like
+            // mail-this-that-co-uk.dkim1._domainkey.firebasemail.com
+            // selector1-this.co.uk._domainkey.that.onmicrosoft.com 
+            // Attempting to use the DomainParser to validate that these relate to real TLDs does not work when using the Uri class
+
+            // these domains produce the same result for both normalization methods.
+            this.PerformParsingCheck("_abc.def.ghi.jkl.com", "jkl.com", "jkl.com");
+            this.PerformParsingCheck("abc._def.ghi.jkl.com", "jkl.com", "jkl.com");
+            this.PerformParsingCheck("def._ghi.jkl.com", "jkl.com", "jkl.com");
+
+            // These domains are treated as invalid and produce null via the Uri normalization method.
+            // def._ghi.jkl.com is valid but
+            // abc.def._ghi.jkl.com is invalid.
+            // It can't be correct that adding abc. in front of a valid domain makes it invalid
+            this.PerformParsingCheck("abc.def._ghi.jkl.com", null, "jkl.com");
+        }
+
+        [TestMethod]
+        public void SingleWordTest()
+        {
+            this.PerformParsingCheck("singleword", null, null);
+        }
+
+        [TestMethod]
+        public void SimpleNumberTest()
+        {
+            // Uri object transforms 12344 to 48.57 because 12345 = (48 * 256) + (57 * 1)
+            // This creates two parts separated by a dot which allows the rule-matching to handle it like a domain name
+            // Whereas the IdnMapper does not do this so the rule-matching fails because the 'domain name' is just a single word with no dot.
+            this.PerformParsingCheck("12345", "48.57", null);
+        }
+
+        [TestMethod]
+        public void DashBasedVariations()
+        {
+            // Adding sub domains to these examples demonstrates how the Uri validation behaves in an unexpected way.
+            // For example "sub.-example.com" is valid but "double.sub.-example.com" is not.
+
+            this.PerformParsingCheck("-example.com", "-example.com", "-example.com");
+            this.PerformParsingCheck("example.-com", "example.-com", "example.-com");
+            this.PerformParsingCheck("example.com-", "example.com-", "example.com-");
+            this.PerformParsingCheck("example.-com-", "example.-com-", "example.-com-");
+
+            this.PerformParsingCheck("sub.-example.com", "-example.com", "-example.com");
+            this.PerformParsingCheck("sub.example.-com", null, "example.-com");
+            this.PerformParsingCheck("sub.example.com-", "example.com-", "example.com-");
+            this.PerformParsingCheck("sub.example.-com-", null, "example.-com-");
+
+            this.PerformParsingCheck("double.sub.-example.com", null, "-example.com");
+            this.PerformParsingCheck("double.sub.example.-com", null, "example.-com");
+            this.PerformParsingCheck("double.sub.example.com-", "example.com-", "example.com-");
+            this.PerformParsingCheck("double.sub.example.-com-", null, "example.-com-");
+        }
+
+        private void PerformParsingCheck(string domain, string expectedRegistrableDomain_UriVersion, string expectedRegistrableDomain_IdnVersion)
+        {
+            this.PerformParsingCheckUsingParser(domain, expectedRegistrableDomain_UriVersion, this._parserUsingUriNormalization, "uri normalizing parser");
+            this.PerformParsingCheckUsingParser(domain, expectedRegistrableDomain_IdnVersion, this._parserUsingIdnNormalization, "idn normalizing parser");
+        }
+
+        private void PerformParsingCheckUsingParser(string domain, string expectedRegistrableDomain, DomainParser parserToCheckWith, string parserDescription)
+        {
+            var domainData = parserToCheckWith.Get(domain);
+            if (domainData == null)
+            {
+                Assert.IsNull(expectedRegistrableDomain, $"{parserDescription} produced null instead of {expectedRegistrableDomain} from {domain}");
+            }
+            else
+            {
+                Assert.AreEqual(expectedRegistrableDomain, domainData.RegistrableDomain, $"{parserDescription} produced {domainData.RegistrableDomain} instead of {expectedRegistrableDomain ?? "null" } from {domain}");
+            }
+        }
+    }
+}

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
@@ -162,5 +162,20 @@ namespace Nager.PublicSuffix.UnitTest
             this.CheckPublicSuffix("web.blogspot.co.ke", "web.blogspot.co.ke");
             this.CheckPublicSuffix("a.b.web.blogspot.co.ke", "web.blogspot.co.ke");
         }
+
+        [TestMethod]
+        public void UnderscoreCheck()
+        {
+            this.CheckPublicSuffix("_abc.def.ghi.jkl.com", "jkl.com");
+            this.CheckPublicSuffix("abc._def.ghi.jkl.com", "jkl.com");
+            this.CheckPublicSuffix("def._ghi.jkl.com", "jkl.com");
+
+            // These tests demonstrate unwanted behaviour due to a 'bug' in Uri construction
+            // def._ghi.jkl.com is valid but
+            // abc.def._ghi.jkl.com is invalid.
+            // It can't be correct that adding abc. in front of a valid domain makes in invalid
+            this.CheckPublicSuffix("abc.def._ghi.jkl.com", null);
+            this.CheckPublicSuffix("abc.def.ghi._jkl.com", null);
+        }
     }
 }

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
@@ -23,11 +23,6 @@ namespace Nager.PublicSuffix.UnitTest
         {
             Assert.IsNotNull(this._domainParser, "_domainParser is null");
 
-            if (!string.IsNullOrEmpty(domain))
-            {
-                domain = domain.ToLowerInvariant();
-            }
-
             var domainData = this._domainParser.Get(domain);
             if (domainData == null)
             {

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
@@ -1,25 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
-using System.Linq;
 
 namespace Nager.PublicSuffix.UnitTest
 {
-    [TestClass]
-    public class PublicSuffixTest
+    public abstract class PublicSuffixTest
     {
-        private DomainParser _domainParser;
+        protected DomainParser _domainParser;
 
         //Run tests as specified here:
         //https://raw.githubusercontent.com/publicsuffix/list/master/tests/test_psl.txt
 
-        [TestInitialize()]
-        public void Initialize()
-        {
-            var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"));
-            this._domainParser = domainParser;
-        }
-
-        private void CheckPublicSuffix(string domain, string expected)
+        protected void CheckPublicSuffix(string domain, string expected)
         {
             Assert.IsNotNull(this._domainParser, "_domainParser is null");
 
@@ -161,21 +151,6 @@ namespace Nager.PublicSuffix.UnitTest
             this.CheckPublicSuffix("blogspot.co.ke", null);
             this.CheckPublicSuffix("web.blogspot.co.ke", "web.blogspot.co.ke");
             this.CheckPublicSuffix("a.b.web.blogspot.co.ke", "web.blogspot.co.ke");
-        }
-
-        [TestMethod]
-        public void UnderscoreCheck()
-        {
-            this.CheckPublicSuffix("_abc.def.ghi.jkl.com", "jkl.com");
-            this.CheckPublicSuffix("abc._def.ghi.jkl.com", "jkl.com");
-            this.CheckPublicSuffix("def._ghi.jkl.com", "jkl.com");
-
-            // These tests demonstrate unwanted behaviour due to a 'bug' in Uri construction
-            // def._ghi.jkl.com is valid but
-            // abc.def._ghi.jkl.com is invalid.
-            // It can't be correct that adding abc. in front of a valid domain makes it invalid
-            this.CheckPublicSuffix("abc.def._ghi.jkl.com", null);
-            this.CheckPublicSuffix("abc.def.ghi._jkl.com", null);
         }
     }
 }

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTest.cs
@@ -173,7 +173,7 @@ namespace Nager.PublicSuffix.UnitTest
             // These tests demonstrate unwanted behaviour due to a 'bug' in Uri construction
             // def._ghi.jkl.com is valid but
             // abc.def._ghi.jkl.com is invalid.
-            // It can't be correct that adding abc. in front of a valid domain makes in invalid
+            // It can't be correct that adding abc. in front of a valid domain makes it invalid
             this.CheckPublicSuffix("abc.def._ghi.jkl.com", null);
             this.CheckPublicSuffix("abc.def.ghi._jkl.com", null);
         }

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithIdnMappingNormalization.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithIdnMappingNormalization.cs
@@ -11,17 +11,5 @@ namespace Nager.PublicSuffix.UnitTest
             var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"), new IdnMappingNormalizer());
             this._domainParser = domainParser;
         }
-
-        [TestMethod]
-        public void UnderscoreCheck()
-        {
-            this.CheckPublicSuffix("_abc.def.ghi.jkl.com", "jkl.com");
-            this.CheckPublicSuffix("abc._def.ghi.jkl.com", "jkl.com");
-            this.CheckPublicSuffix("def._ghi.jkl.com", "jkl.com");
-
-            // These tests demonstrate the wanted behaviour avoiding the 'bug' in Uri construction
-            this.CheckPublicSuffix("abc.def._ghi.jkl.com", "jkl.com");
-            this.CheckPublicSuffix("abc.def.ghi._jkl.com", "_jkl.com");
-        }
     }
 }

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithIdnMappingNormalization.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithIdnMappingNormalization.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Nager.PublicSuffix.UnitTest
+{
+    [TestClass]
+    public class PublicSuffixTestsWithIdnMappingNormalization : PublicSuffixTest
+    {
+        [TestInitialize()]
+        public void Initialize()
+        {
+            var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"), new IdnMappingNormalizer());
+            this._domainParser = domainParser;
+        }
+
+        [TestMethod]
+        public void UnderscoreCheck()
+        {
+            this.CheckPublicSuffix("_abc.def.ghi.jkl.com", "jkl.com");
+            this.CheckPublicSuffix("abc._def.ghi.jkl.com", "jkl.com");
+            this.CheckPublicSuffix("def._ghi.jkl.com", "jkl.com");
+
+            // These tests demonstrate the wanted behaviour avoiding the 'bug' in Uri construction
+            this.CheckPublicSuffix("abc.def._ghi.jkl.com", "jkl.com");
+            this.CheckPublicSuffix("abc.def.ghi._jkl.com", "_jkl.com");
+        }
+    }
+}

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithUriNormalization.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithUriNormalization.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Nager.PublicSuffix.UnitTest
+{
+    [TestClass]
+    public class PublicSuffixTestsWithUriNormalization : PublicSuffixTest
+    {
+        [TestInitialize()]
+        public void Initialize()
+        {
+            var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"));
+            this._domainParser = domainParser;
+        }
+
+        [TestMethod]
+        public void UnderscoreCheck()
+        {
+            this.CheckPublicSuffix("_abc.def.ghi.jkl.com", "jkl.com");
+            this.CheckPublicSuffix("abc._def.ghi.jkl.com", "jkl.com");
+            this.CheckPublicSuffix("def._ghi.jkl.com", "jkl.com");
+
+            // These tests demonstrate unwanted behaviour due to a 'bug' in Uri construction
+            // def._ghi.jkl.com is valid but
+            // abc.def._ghi.jkl.com is invalid.
+            // It can't be correct that adding abc. in front of a valid domain makes it invalid
+            this.CheckPublicSuffix("abc.def._ghi.jkl.com", null);
+            this.CheckPublicSuffix("abc.def.ghi._jkl.com", null);
+        }
+    }
+}

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithUriNormalization.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithUriNormalization.cs
@@ -8,7 +8,7 @@ namespace Nager.PublicSuffix.UnitTest
         [TestInitialize()]
         public void Initialize()
         {
-            var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"));
+            var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"), new UriNormalizer());
             this._domainParser = domainParser;
         }
 

--- a/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithUriNormalization.cs
+++ b/Nager.PublicSuffix.UnitTest/PublicSuffixTestsWithUriNormalization.cs
@@ -11,20 +11,5 @@ namespace Nager.PublicSuffix.UnitTest
             var domainParser = new DomainParser(new FileTldRuleProvider("effective_tld_names.dat"), new UriNormalizer());
             this._domainParser = domainParser;
         }
-
-        [TestMethod]
-        public void UnderscoreCheck()
-        {
-            this.CheckPublicSuffix("_abc.def.ghi.jkl.com", "jkl.com");
-            this.CheckPublicSuffix("abc._def.ghi.jkl.com", "jkl.com");
-            this.CheckPublicSuffix("def._ghi.jkl.com", "jkl.com");
-
-            // These tests demonstrate unwanted behaviour due to a 'bug' in Uri construction
-            // def._ghi.jkl.com is valid but
-            // abc.def._ghi.jkl.com is invalid.
-            // It can't be correct that adding abc. in front of a valid domain makes it invalid
-            this.CheckPublicSuffix("abc.def._ghi.jkl.com", null);
-            this.CheckPublicSuffix("abc.def.ghi._jkl.com", null);
-        }
     }
 }

--- a/Nager.PublicSuffix.UnitTest/TldRuleTest.cs
+++ b/Nager.PublicSuffix.UnitTest/TldRuleTest.cs
@@ -7,14 +7,14 @@ namespace Nager.PublicSuffix.UnitTest
     public class TldRuleTest
     {
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "RuleData is emtpy")]
+        [ExpectedException(typeof(ArgumentException), "RuleData is empty")]
         public void InvalidRuleTest1()
         {
             new TldRule("");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException), "RuleData is emtpy")]
+        [ExpectedException(typeof(ArgumentException), "RuleData is empty")]
         public void InvalidRuleTest2()
         {
             new TldRule(null);

--- a/Nager.PublicSuffix/DomainParser.cs
+++ b/Nager.PublicSuffix/DomainParser.cs
@@ -78,7 +78,42 @@ namespace Nager.PublicSuffix
                 .Reverse()
                 .ToList();
 
-            if (parts.Count == 0 || parts.Any(x => x.Equals(string.Empty)))
+            return this.GetDomainFromParts(normalizedDomain, parts);
+        }
+
+        public DomainName Get(string domain)
+        {
+            if (string.IsNullOrEmpty(domain))
+            {
+                return null;
+            }
+
+            //We use Uri methods to normalize host (So Punycode is converted to UTF-8
+            if (!domain.Contains("https://"))
+            {
+                domain = string.Concat("https://", domain);
+            }
+
+            Uri uri;
+            if (!Uri.TryCreate(domain, UriKind.RelativeOrAbsolute, out uri))
+            {
+                return null;
+            }
+
+            var normalizedDomain = uri.Host;
+            var normalizedHost = uri.GetComponents(UriComponents.NormalizedHost, UriFormat.UriEscaped); //Normalize punycode
+
+            var parts = normalizedHost
+                .Split('.')
+                .Reverse()
+                .ToList();
+
+            return this.GetDomainFromParts(normalizedDomain, parts);
+        }
+
+        private DomainName GetDomainFromParts(string domain, List<string> parts)
+        {
+            if (parts == null || parts.Count == 0 || parts.Any(x => x.Equals(string.Empty)))
             {
                 return null;
             }
@@ -104,30 +139,8 @@ namespace Nager.PublicSuffix
                 return null;
             }
 
-            var domainName = new DomainName(normalizedDomain, winningRule);
+            var domainName = new DomainName(domain, winningRule);
             return domainName;
-        }
-
-        public DomainName Get(string domain)
-        {
-            if (string.IsNullOrEmpty(domain))
-            {
-                return null;
-            }
-
-            //We use Uri methods to normalize host (So Punycode is converted to UTF-8
-            if (!domain.Contains("https://"))
-            {
-                domain = string.Concat("https://", domain);
-            }
-
-            Uri uri;
-            if (!Uri.TryCreate(domain, UriKind.RelativeOrAbsolute, out uri))
-            {
-                return null;
-            }
-
-            return Get(uri);
         }
 
         private void FindMatches(IEnumerable<string> parts, DomainDataStructure structure, List<TldRule> matches)

--- a/Nager.PublicSuffix/DomainParser.cs
+++ b/Nager.PublicSuffix/DomainParser.cs
@@ -73,7 +73,7 @@ namespace Nager.PublicSuffix
 
         public DomainName Get(Uri domain)
         {
-            var normalizedDomain = domain.Host;
+            var partlyNormalizedDomain = domain.Host;
             var normalizedHost = domain.GetComponents(UriComponents.NormalizedHost, UriFormat.UriEscaped); //Normalize punycode
 
             var parts = normalizedHost
@@ -81,13 +81,13 @@ namespace Nager.PublicSuffix
                 .Reverse()
                 .ToList();
 
-            return this.GetDomainFromParts(normalizedDomain, parts);
+            return this.GetDomainFromParts(partlyNormalizedDomain, parts);
         }
 
         public DomainName Get(string domain)
         {
-            var parts = this._domainNormalizer.NormalizeDomainAndExtractParts(domain, out string normalizedDomain);
-            return this.GetDomainFromParts(normalizedDomain, parts);
+            var parts = this._domainNormalizer.PartlyNormalizeDomainAndExtractFullyNormalizedParts(domain, out string partlyNormalizedDomain);
+            return this.GetDomainFromParts(partlyNormalizedDomain, parts);
         }
 
         private DomainName GetDomainFromParts(string domain, List<string> parts)

--- a/Nager.PublicSuffix/DomainParser.cs
+++ b/Nager.PublicSuffix/DomainParser.cs
@@ -8,6 +8,7 @@ namespace Nager.PublicSuffix
     {
         private DomainDataStructure _domainDataStructure;
         private readonly ITldRuleProvider _ruleProvider;
+        private IDomainNormalizer _domainNormalizer = new UriNormalizer();
 
         public DomainParser(IEnumerable<TldRule> rules)
         {
@@ -83,31 +84,7 @@ namespace Nager.PublicSuffix
 
         public DomainName Get(string domain)
         {
-            if (string.IsNullOrEmpty(domain))
-            {
-                return null;
-            }
-
-            //We use Uri methods to normalize host (So Punycode is converted to UTF-8
-            if (!domain.Contains("https://"))
-            {
-                domain = string.Concat("https://", domain);
-            }
-
-            Uri uri;
-            if (!Uri.TryCreate(domain, UriKind.RelativeOrAbsolute, out uri))
-            {
-                return null;
-            }
-
-            var normalizedDomain = uri.Host;
-            var normalizedHost = uri.GetComponents(UriComponents.NormalizedHost, UriFormat.UriEscaped); //Normalize punycode
-
-            var parts = normalizedHost
-                .Split('.')
-                .Reverse()
-                .ToList();
-
+            var parts = this._domainNormalizer.NormalizeDomainAndExtractParts(domain, out string normalizedDomain);
             return this.GetDomainFromParts(normalizedDomain, parts);
         }
 

--- a/Nager.PublicSuffix/DomainParser.cs
+++ b/Nager.PublicSuffix/DomainParser.cs
@@ -8,22 +8,24 @@ namespace Nager.PublicSuffix
     {
         private DomainDataStructure _domainDataStructure;
         private readonly ITldRuleProvider _ruleProvider;
-        private IDomainNormalizer _domainNormalizer = new UriNormalizer();
+        private IDomainNormalizer _domainNormalizer;
 
-        public DomainParser(IEnumerable<TldRule> rules)
+        public DomainParser(IEnumerable<TldRule> rules, IDomainNormalizer domainNormalizer = null)
         {
             if (rules == null)
             {
                 throw new ArgumentNullException("rules");
             }
 
-            this.AddRules(rules);
+            Initialize(rules, domainNormalizer);
         }
 
-        public DomainParser(ITldRuleProvider ruleProvider)
+        public DomainParser(ITldRuleProvider ruleProvider, IDomainNormalizer domainNormalizer = null)
         {
             this._ruleProvider = ruleProvider ?? throw new ArgumentNullException("ruleProvider");
-            this.AddRules(ruleProvider.BuildAsync().Result);
+
+            var rules = ruleProvider.BuildAsync().Result;
+            this.Initialize(rules, domainNormalizer);
         }
 
         public void AddRules(IEnumerable<TldRule> tldRules)
@@ -143,6 +145,12 @@ namespace Nager.PublicSuffix
             {
                 FindMatches(parts.Skip(1), foundStructure, matches);
             }
+        }
+
+        private void Initialize(IEnumerable<TldRule> rules, IDomainNormalizer domainNormalizer)
+        {
+            this.AddRules(rules);
+            this._domainNormalizer = domainNormalizer ?? new UriNormalizer();
         }
     }
 }

--- a/Nager.PublicSuffix/FileCacheProvider.cs
+++ b/Nager.PublicSuffix/FileCacheProvider.cs
@@ -41,7 +41,7 @@ namespace Nager.PublicSuffix
 
         public Task<string> GetValueAsync()
         {
-            if (!IsCacheValid())
+            if (!this.IsCacheValid())
             {
                 return Task.FromResult<string>(null);
             }

--- a/Nager.PublicSuffix/FileTldRuleProvider.cs
+++ b/Nager.PublicSuffix/FileTldRuleProvider.cs
@@ -15,21 +15,21 @@ namespace Nager.PublicSuffix
 
         public async Task<IEnumerable<TldRule>> BuildAsync()
         {
-            var ruleData = await this.LoadFromFile(_fileName).ConfigureAwait(false);
+            var ruleData = await this.LoadFromFile().ConfigureAwait(false);
 
             var ruleParser = new TldRuleParser();
             var rules = ruleParser.ParseRules(ruleData);
             return rules;
         }
 
-        private async Task<string> LoadFromFile(string fileName)
+        private async Task<string> LoadFromFile()
         {
-            if (!File.Exists(_fileName))
+            if (!File.Exists(this._fileName))
             {
                 throw new FileNotFoundException("Rule file does not exist");
             }
 
-            using (var reader = File.OpenText(fileName))
+            using (var reader = File.OpenText(this._fileName))
             {
                 return await reader.ReadToEndAsync().ConfigureAwait(false);
             }

--- a/Nager.PublicSuffix/IDomainNormalizer.cs
+++ b/Nager.PublicSuffix/IDomainNormalizer.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Nager.PublicSuffix
+{
+    public interface IDomainNormalizer
+    {
+        List<string> NormalizeDomainAndExtractParts(string domain, out string normalizedDomain);
+    }
+}

--- a/Nager.PublicSuffix/IDomainNormalizer.cs
+++ b/Nager.PublicSuffix/IDomainNormalizer.cs
@@ -4,6 +4,6 @@ namespace Nager.PublicSuffix
 {
     public interface IDomainNormalizer
     {
-        List<string> NormalizeDomainAndExtractParts(string domain, out string normalizedDomain);
+        List<string> PartlyNormalizeDomainAndExtractFullyNormalizedParts(string domain, out string partlyNormalizedDomain);
     }
 }

--- a/Nager.PublicSuffix/IdnMappingNormalizer.cs
+++ b/Nager.PublicSuffix/IdnMappingNormalizer.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Nager.PublicSuffix
+{
+    public class IdnMappingNormalizer : IDomainNormalizer
+    {
+        private readonly IdnMapping _idnMapping = new IdnMapping();
+
+        public List<string> PartlyNormalizeDomainAndExtractFullyNormalizedParts(string domain, out string partlyNormalizedDomain)
+        {
+            partlyNormalizedDomain = null;
+
+            if (string.IsNullOrEmpty(domain))
+            {
+                return null;
+            }
+
+            partlyNormalizedDomain = domain.ToLowerInvariant();
+
+            string punycodeConvertedDomain = partlyNormalizedDomain;
+            if (partlyNormalizedDomain.Contains("xn--"))
+            {
+                punycodeConvertedDomain = this._idnMapping.GetUnicode(partlyNormalizedDomain);
+            }
+
+            return punycodeConvertedDomain
+                .Split('.')
+                .Reverse()
+                .ToList();
+        }
+    }
+}

--- a/Nager.PublicSuffix/TldRule.cs
+++ b/Nager.PublicSuffix/TldRule.cs
@@ -14,7 +14,7 @@ namespace Nager.PublicSuffix
         {
             if (string.IsNullOrEmpty(ruleData))
             {
-                throw new ArgumentException("RuleData is emtpy");
+                throw new ArgumentException("RuleData is empty");
             }
 
             this.Division = division;

--- a/Nager.PublicSuffix/UriNormalizer.cs
+++ b/Nager.PublicSuffix/UriNormalizer.cs
@@ -6,9 +6,9 @@ namespace Nager.PublicSuffix
 {
     public class UriNormalizer : IDomainNormalizer
     {
-        public List<string> NormalizeDomainAndExtractParts(string domain, out string normalizedDomain)
+        public List<string> PartlyNormalizeDomainAndExtractFullyNormalizedParts(string domain, out string partlyNormalizedDomain)
         {
-            normalizedDomain = null;
+            partlyNormalizedDomain = null;
 
             if (string.IsNullOrEmpty(domain))
             {
@@ -26,7 +26,7 @@ namespace Nager.PublicSuffix
                 return null;
             }
 
-            normalizedDomain = uri.Host;
+            partlyNormalizedDomain = uri.Host;
             var normalizedHost = uri.GetComponents(UriComponents.NormalizedHost, UriFormat.UriEscaped); //Normalize punycode
 
             return normalizedHost

--- a/Nager.PublicSuffix/UriNormalizer.cs
+++ b/Nager.PublicSuffix/UriNormalizer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nager.PublicSuffix
+{
+    public class UriNormalizer : IDomainNormalizer
+    {
+        public List<string> NormalizeDomainAndExtractParts(string domain, out string normalizedDomain)
+        {
+            normalizedDomain = null;
+
+            if (string.IsNullOrEmpty(domain))
+            {
+                return null;
+            }
+
+            //We use Uri methods to normalize host (So Punycode is converted to UTF-8 
+            if (!domain.Contains("https://"))
+            {
+                domain = string.Concat("https://", domain);
+            }
+
+            if (!Uri.TryCreate(domain, UriKind.RelativeOrAbsolute, out Uri uri))
+            {
+                return null;
+            }
+
+            normalizedDomain = uri.Host;
+            var normalizedHost = uri.GetComponents(UriComponents.NormalizedHost, UriFormat.UriEscaped); //Normalize punycode
+
+            return normalizedHost
+                .Split('.')
+                .Reverse()
+                .ToList();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PM> install-package Nager.PublicSuffix
 If this project help you reduce time to develop, you can give me a beer :beer:
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/nagerat/25)
 
-### Exampels
+### Examples
 
 #### Load data from web (publicsuffix.org)
 ```cs


### PR DESCRIPTION
The DomainParser needs to translate from punycode to UTF8 to match against the Public Suffix List which is UTF8.
It uses the Uri class to do this. This introduces additional behaviour in validating and transforming the domain name being parsed. Sometimes this behaviour is not wanted.

This set of changes provides a way of using the IdnMapping class to perform only punycode translation and not the other behaviour. 

To do this it moves the 'normalization' of the domain out of the DomainParser and into an injectable IDomainNormalizer helper. Two of these are provided. One of them (the UriNormalizer) maintains existing behaviour and is used by default. The other (the IdnMappingNormalizer) provides an alternative technique.