### PR TITLE
New ctor to take initialized DomainDataStructure

### DIFF
--- a/src/Nager.PublicSuffix.UnitTest/DomainNameTestsWithInitializedStructure.cs
+++ b/src/Nager.PublicSuffix.UnitTest/DomainNameTestsWithInitializedStructure.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.PublicSuffix.Extensions;
+using System.Collections.Generic;
+
+namespace Nager.PublicSuffix.UnitTest
+{
+    [TestClass]
+    public class DomainNameTestsWithInitializedStructure : DomainNameTest
+    {
+        protected override DomainParser GetParserForRules(List<TldRule> rules)
+        {
+            var structure = new DomainDataStructure("*", new TldRule("*"));
+            structure.AddRules(rules);
+            return new DomainParser(structure);
+        }
+    }
+}

--- a/src/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
+++ b/src/Nager.PublicSuffix.UnitTest/Nager.PublicSuffix.UnitTest.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="AsyncAwaitTest.cs" />
     <Compile Include="DomainNameTestsWithIdnMappingNormalization.cs" />
+    <Compile Include="DomainNameTestsWithInitializedStructure.cs" />
     <Compile Include="DomainNameTestsWithUriNormalization.cs" />
     <Compile Include="NormalizationVariationTests.cs" />
     <Compile Include="PublicSuffixTest.cs" />

--- a/src/Nager.PublicSuffix.Website/Controllers/PublicSuffixController.cs
+++ b/src/Nager.PublicSuffix.Website/Controllers/PublicSuffixController.cs
@@ -9,10 +9,17 @@ namespace Nager.PublicSuffix.Website.Controllers
     [ApiController]
     public class PublicSuffixController : ControllerBase
     {
+        private readonly DomainDataStructure _domainDataStructure;
+
+        public PublicSuffixController(DomainDataStructure domainDataStructure)
+        {
+            _domainDataStructure = domainDataStructure;
+        }
+
         [HttpGet]
         public ActionResult<Task<DomainReport>> Get(string domain)
         {
-            var domainParser = new DomainParser(new WebTldRuleProvider());
+            var domainParser = new DomainParser(_domainDataStructure);
             var domainName = domainParser.Get(domain);
             var valid = domainParser.IsValidDomain(domain);
 

--- a/src/Nager.PublicSuffix.Website/Startup.cs
+++ b/src/Nager.PublicSuffix.Website/Startup.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Nager.PublicSuffix.Extensions;
 
 namespace Nager.PublicSuffix.Website
 {
@@ -25,6 +19,15 @@ namespace Nager.PublicSuffix.Website
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton(svcs =>
+            {
+                var provider = new WebTldRuleProvider();
+                var rules = provider.BuildAsync().GetAwaiter().GetResult();
+                var structure = new DomainDataStructure("*", new TldRule("*"));
+                structure.AddRules(rules);
+                return structure;
+            });
+
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 

--- a/src/Nager.PublicSuffix/DomainDataStructure.cs
+++ b/src/Nager.PublicSuffix/DomainDataStructure.cs
@@ -2,18 +2,41 @@
 
 namespace Nager.PublicSuffix
 {
-    internal class DomainDataStructure
+    /// <summary>
+    /// Represents a tree of TLD domains
+    /// </summary>
+    public class DomainDataStructure
     {
-        public string Domain { get; internal set; }
-        public TldRule TldRule { get; internal set; }
-        public Dictionary<string, DomainDataStructure> Nested { get; internal set; }
+        /// <summary>
+        /// The TLD Domain
+        /// </summary>
+        public string Domain { get; set; }
 
+        /// <summary>
+        /// The type of TLD Domain. <see cref="TldRule"/>.
+        /// </summary>
+        public TldRule TldRule { get; set; }
+
+        /// <summary>
+        /// The children of this TLD Domain
+        /// </summary>
+        public Dictionary<string, DomainDataStructure> Nested { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="DomainDataStructure"/> for <paramref name="domain"/>.
+        /// </summary>
+        /// <param name="domain">The Domain.</param>
         public DomainDataStructure(string domain)
         {
             this.Domain = domain;
             this.Nested = new Dictionary<string, DomainDataStructure>();
         }
 
+        /// <summary>
+        /// Creates a new <see cref="DomainDataStructure"/> for <paramref name="domain"/>.
+        /// </summary>
+        /// <param name="domain">The Domain.</param>
+        /// <param name="tldRule">The type of TLD domain.</param>
         public DomainDataStructure(string domain, TldRule tldRule)
         {
             this.Domain = domain;

--- a/src/Nager.PublicSuffix/Extensions/DomainDataStructureExtensions.cs
+++ b/src/Nager.PublicSuffix/Extensions/DomainDataStructureExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Nager.PublicSuffix.Extensions
+{
+    /// <summary>
+    /// <see cref="DomainDataStructure"/> extension methods to create the TLD Tree.
+    /// </summary>
+    public static class DomainDataStructureExtensions
+    {
+        /// <summary>
+        /// Add all the rules in <paramref name="tldRules"/> to <paramref name="structure"/>.
+        /// </summary>
+        /// <param name="structure">The structure to appened the rule.</param>
+        /// <param name="tldRules">The rules to append.</param>
+        public static void AddRules(this DomainDataStructure structure, IEnumerable<TldRule> tldRules)
+        {
+            foreach (var tldRule in tldRules)
+            {
+                structure.AddRule(tldRule);
+            }
+        }
+
+        /// <summary>
+        /// Add <paramref name="tldRule"/> to <paramref name="structure"/>.
+        /// </summary>
+        /// <param name="structure">The structure to appened the rule.</param>
+        /// <param name="tldRule">The rule to append.</param>
+        public static void AddRule(this DomainDataStructure structure, TldRule tldRule)
+        {
+            var parts = tldRule.Name.Split('.').Reverse().ToList();
+            for (var i = 0; i < parts.Count; i++)
+            {
+                var domainPart = parts[i];
+                if (parts.Count - 1 > i)
+                {
+                    //Check if domain exists
+                    if (!structure.Nested.ContainsKey(domainPart))
+                    {
+                        structure.Nested.Add(domainPart, new DomainDataStructure(domainPart));
+                    }
+
+                    structure = structure.Nested[domainPart];
+                    continue;
+                }
+
+                //Check if domain exists
+                if (structure.Nested.ContainsKey(domainPart))
+                {
+                    structure.Nested[domainPart].TldRule = tldRule;
+                    continue;
+                }
+
+                structure.Nested.Add(domainPart, new DomainDataStructure(domainPart, tldRule));
+            }
+        }
+    }
+}

--- a/src/Nager.PublicSuffix/Nager.PublicSuffix.csproj
+++ b/src/Nager.PublicSuffix/Nager.PublicSuffix.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net45;net461;netstandard2.0</TargetFrameworks>


### PR DESCRIPTION
- Add new ctor to `DomainParser` to accept an initialized `DomainDataStructure`.
#35 